### PR TITLE
Asynchronous import module

### DIFF
--- a/app/code/Magento/ImportService/Api/Data/ImportConfigInterface.php
+++ b/app/code/Magento/ImportService/Api/Data/ImportConfigInterface.php
@@ -19,6 +19,7 @@ interface ImportConfigInterface extends ExtensibleDataInterface
     const VALIDATION_STRATEGY = 'validation_strategy';
     const IMPORT_IMAGE_ARCHIVE = 'import_image_archive';
     const IMPORT_IMAGES_FILE_DIR = 'import_images_file_dir';
+    const MAPPING = 'mapping';
 
     /**
      * @return string

--- a/app/code/Magento/ImportService/Api/Data/ImportConfigInterface.php
+++ b/app/code/Magento/ImportService/Api/Data/ImportConfigInterface.php
@@ -73,6 +73,16 @@ interface ImportConfigInterface extends ExtensibleDataInterface
     public function setImportImagesFileDir(string $importImagesFileDir): void;
 
     /**
+     * @return ImportConfigMappingInterface
+     */
+    public function getMapping(): ImportConfigMappingInterface;
+
+    /**
+     * @param ImportConfigMappingInterface $mapping
+     */
+    public function setMapping(ImportConfigMappingInterface $mapping): void;
+
+    /**
      * @return \Magento\ImportService\Api\Data\ImportConfigExtensionInterface
      */
     public function getExtensionAttributes(): \Magento\ImportService\Api\Data\ImportConfigExtensionInterface;

--- a/app/code/Magento/ImportService/Api/Data/ImportConfigMappingInterface.php
+++ b/app/code/Magento/ImportService/Api/Data/ImportConfigMappingInterface.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ImportService\Api\Data;
+
+use Magento\Tests\NamingConvention\true\string;
+
+/**
+ * Interface ImportConfigMappingInterface
+ */
+interface ImportConfigMappingInterface
+{
+    const NAME = 'name';
+    const SOURCE_PATH = 'source_path';
+    const TARGET_PATH = 'target_path';
+    const TARGET_VALUE = 'target_value';
+    const PROCESSING_RULES = 'processing_rules';
+
+    /**
+     * @return string
+     */
+    public function getName(): string;
+
+    /**
+     * @param string $name
+     */
+    public function setName(string $name): void;
+
+    /**
+     * @return string
+     */
+    public function getSourcePath(): string;
+
+    /**
+     * @param string $sourcePath
+     */
+    public function setSourcePath(string $sourcePath): void;
+
+    /**
+     * @return string
+     */
+    public function getTargetPath(): string;
+
+    /**
+     * @param string $targetPath
+     */
+    public function setTargetPath(string $targetPath): void;
+
+    /**
+     * @return string
+     */
+    public function getTargetValue(): string;
+
+    /**
+     * @param string $targetValue
+     */
+    public function setTargetValue(string $targetValue): void;
+
+    /**
+     * @return ImportConfigMappingProcessingRulesInterface
+     */
+    public function getProcessingRules(): ImportConfigMappingProcessingRulesInterface;
+
+    /**
+     * @param ImportConfigMappingProcessingRulesInterface $processingRules
+     */
+    public function setProcessingRules(ImportConfigMappingProcessingRulesInterface $processingRules): void;
+}

--- a/app/code/Magento/ImportService/Api/Data/ImportConfigMappingProcessingRulesInterface.php
+++ b/app/code/Magento/ImportService/Api/Data/ImportConfigMappingProcessingRulesInterface.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ImportService\Api\Data;
+
+use Magento\Tests\NamingConvention\true\string;
+
+/**
+ * Interface ImportConfigMappingInterface
+ */
+interface ImportConfigMappingProcessingRulesInterface
+{
+    const SORT = 'sort';
+    const FUNCTION = 'function';
+    const args = 'args';
+
+    /**
+     * @return string
+     */
+    public function getSort(): string;
+
+    /**
+     * @param string $sort
+     */
+    public function setSort(string $sort): void;
+
+    /**
+     * @return string
+     */
+    public function getFunction(): string;
+
+    /**
+     * @param string $function
+     */
+    public function setFunction(string $function): void;
+
+    /**
+     * @return string
+     */
+    public function getArgs(): string;
+
+    /**
+     * @param string $args
+     */
+    public function setArgs(string $args): void;
+}

--- a/app/code/Magento/ImportService/etc/webapi.xml
+++ b/app/code/Magento/ImportService/etc/webapi.xml
@@ -19,7 +19,7 @@
             <resource ref="Magento_ImportService::import" />
         </resources>
     </route>
-    <route url="/V1/import/type/:type/start/:uuid" method="POST">
+    <route url="/V1/import/start/:uuid" method="POST">
         <service class="Magento\ImportService\Api\ImportStartInterface" method="execute"/>
         <resources>
             <resource ref="Magento_ImportService::import" />


### PR DESCRIPTION
Implement interfaces for Start Import endpoint #111

Description (*)
Change Import start endpoint:
From:
/V1/import/type/:type/start/:uuid
to
/V1/import/start/:uuid

Move "mapping" paramethers for body from
/V1/import/source/csv endpoint, to /V1/import/start/:uuid
So final body for import start have to look like this:
https://github.com/magento/architecture/blob/87a6a416f91b13af9b3efdcd1a7f82b0a34363fb/design-documents/asynchronous-import/base-extension.md#main-endpoint

Remove "mapping" from Source upload endpont, so body will looks like:
https://github.com/magento/architecture/blob/87a6a416f91b13af9b3efdcd1a7f82b0a34363fb/design-documents/asynchronous-import/base-extension.md#local-file-path

Implement interfaces